### PR TITLE
check for receiver session lost and update package dependencies

### DIFF
--- a/Test/DurableTask.ServiceBusAMS.Tests/DurableTask.ServiceBusAMS.Tests.csproj
+++ b/Test/DurableTask.ServiceBusAMS.Tests/DurableTask.ServiceBusAMS.Tests.csproj
@@ -36,9 +36,9 @@
     <PackageReference Include="System.Spatial" version="5.8.5" />
     <!-- <PackageReference Include="Azure.Messaging.ServiceBus" version="7.13.1" /> -->
     <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.12.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageReference Include="Azure.Storage.Common" Version="12.13.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.14.0" />
+    <PackageReference Include="Azure.Storage.Common" Version="12.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.ServiceBusAMS/DurableTask.ServiceBusAMS.csproj
+++ b/src/DurableTask.ServiceBusAMS/DurableTask.ServiceBusAMS.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageId>Microsoft.Azure.DurableTask.ServiceBusAMS</PackageId>
   </PropertyGroup>
 
@@ -10,10 +10,10 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>7</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <FileVersion>$(VersionPrefix).1</FileVersion>
+    <FileVersion>$(VersionPrefix).0</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
     <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->
@@ -38,24 +38,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ImpromptuInterface" version="6.2.2" />
-    <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
-    <PackageReference Include="Microsoft.Data.Edm" version="5.8.4" />
-    <PackageReference Include="Microsoft.Data.OData" version="5.8.4" />
-    <PackageReference Include="Microsoft.Data.Services.Client" version="5.8.4" />
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
-    <PackageReference Include="System.Spatial" version="5.8.4" />
     <PackageReference Include="Azure.Messaging.ServiceBus" version="7.11.1" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.12.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageReference Include="Azure.Storage.Common" Version="12.13.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.14.0" />
+    <PackageReference Include="Azure.Storage.Common" Version="12.15.0" />
     <PackageReference Include="System.Linq.Async" Version="4.0.0" />
-    
-    <Reference Include="System.Transactions" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/DurableTask.ServiceBusAMS/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBusAMS/ServiceBusOrchestrationService.cs
@@ -734,7 +734,7 @@ namespace DurableTask.ServiceBus
             var session = sessionState.SessionReceiver;
 
             // check for lock expired by renewing lock
-            RenewTaskOrchestrationWorkItemLockAsync(workItem);
+            await RenewTaskOrchestrationWorkItemLockAsync(workItem);
 
             if (await TrySetSessionStateAsync(workItem, newOrchestrationRuntimeState, runtimeState, session))
             {
@@ -865,7 +865,7 @@ namespace DurableTask.ServiceBus
                     return $"Completing orchestration messages sequence and lock tokens: {allIds}";
                 });
 
-            RenewTaskOrchestrationWorkItemLockAsync(workItem);
+            await RenewTaskOrchestrationWorkItemLockAsync(workItem);
 
             foreach (var value in sessionState.Messages)
             {

--- a/src/DurableTask.ServiceBusAMS/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBusAMS/ServiceBusOrchestrationService.cs
@@ -21,7 +21,6 @@ namespace DurableTask.ServiceBus
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Transactions;
     using DurableTask.Core;
     using DurableTask.Core.Common;
     using DurableTask.Core.Exceptions;
@@ -36,13 +35,7 @@ namespace DurableTask.ServiceBus
     using Azure.Messaging.ServiceBus;
     using Azure.Messaging.ServiceBus.Administration;
     using Azure;
-    using System.Collections;
-    using Microsoft.Azure.Amqp.Framing;
-    using Newtonsoft.Json.Linq;
     using DurableTask.ServiceBus.Common.Abstraction;
-    using Azure.Core.Serialization;
-    using System.Runtime.ExceptionServices;
-
 
     /// <summary>
     /// Orchestration Service and Client implementation using Azure Service Bus
@@ -58,7 +51,7 @@ namespace DurableTask.ServiceBus
         const int SessionStreamWarningSizeInBytes = 150 * 1024;
         const int StatusPollingIntervalInSeconds = 2;
         const int DuplicateDetectionWindowInHours = 4;
-
+        static readonly TimeSpan DurableTaskServiceBusReceiveTimeout = TimeSpan.FromSeconds(30);
         /// <summary>
         /// Orchestration service settings 
         /// </summary>
@@ -172,13 +165,18 @@ namespace DurableTask.ServiceBus
             this.orchestratorEntityName = string.Format(ServiceBusConstants.OrchestratorEndpointFormat, this.hubName);
             this.trackingEntityName = string.Format(ServiceBusConstants.TrackingEndpointFormat, this.hubName);
 
+            var clientOptions = new ServiceBusClientOptions();
+
+            // Set nondefault try timeout
+            clientOptions.RetryOptions.TryTimeout = DurableTaskServiceBusReceiveTimeout;
+
             if (connectionSettings.FullyQualifiedNamespace != null && connectionSettings.TokenCredential != null)
             {
-                this.serviceBusClient = new ServiceBusClient(connectionSettings.FullyQualifiedNamespace, connectionSettings.TokenCredential);
+                this.serviceBusClient = new ServiceBusClient(connectionSettings.FullyQualifiedNamespace, connectionSettings.TokenCredential, clientOptions);
             }
             else if (!string.IsNullOrEmpty(connectionSettings.ConnectionString))
             {
-                this.serviceBusClient = new ServiceBusClient(connectionSettings.ConnectionString);
+                this.serviceBusClient = new ServiceBusClient(connectionSettings.ConnectionString, clientOptions);
             } 
             else
             {
@@ -530,12 +528,19 @@ namespace DurableTask.ServiceBus
         /// <param name="cancellationToken">The cancellation token to cancel execution of the task</param>
         public async Task<TaskOrchestrationWorkItem> LockNextTaskOrchestrationWorkItemAsync(TimeSpan receiveTimeout, CancellationToken cancellationToken)
         {
-            ServiceBusSessionReceiver receiver = await serviceBusClient.AcceptNextSessionAsync(this.orchestratorEntityName);
-            if (receiver == null)
+            ServiceBusSessionReceiver receiver = null;
+            try
             {
-                return null;
+                receiver = await serviceBusClient.AcceptNextSessionAsync(this.orchestratorEntityName);
+            } catch (ServiceBusException ex)
+            {
+                if (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
+                {
+                    // indicates no messages were available or all messages were locked
+                    return null;
+                }
             }
-
+     
             this.ServiceStats.OrchestrationDispatcherStats.SessionsReceived.Increment();
 
             // TODO : Here and elsewhere, consider standard retry block instead of our own hand rolled version
@@ -670,7 +675,31 @@ namespace DurableTask.ServiceBus
             }
 
             TraceHelper.TraceSession(TraceEventType.Information, "ServiceBusOrchestrationService-RenewTaskOrchestrationWorkItem", workItem.InstanceId, "Renew lock on orchestration session");
-            await sessionState.SessionReceiver.RenewSessionLockAsync();
+
+            try
+            {
+                await sessionState.SessionReceiver.RenewSessionLockAsync();
+            } catch (ServiceBusException ex)
+            {
+                if (ex.Reason == ServiceBusFailureReason.SessionLockLost)
+                {
+                    String innerException = ex.InnerException?.Message?.ToString() ?? "no inner exception";
+
+                    TraceHelper.TraceSession(TraceEventType.Warning, "ServiceBusOrchestrationService-RenewTaskOrchestrationWorkItem", workItem.InstanceId, "Session lock lost, renewing. inner exception : " + innerException);
+
+                    try
+                    {
+                        // renew the session
+                        sessionState.SessionReceiver = await serviceBusClient.AcceptSessionAsync(this.orchestratorEntityName, sessionState.SessionReceiver.SessionId);
+                    } catch (ServiceBusException acceptSessionException)
+                    {
+                        throw new Exception($"Could not regain sb session after session lock lost", acceptSessionException);
+                    }
+                } else
+                {
+                    throw ex;
+                }
+            }
             this.ServiceStats.OrchestrationDispatcherStats.SessionsRenewed.Increment();
             workItem.LockedUntilUtc = sessionState.SessionReceiver.SessionLockedUntil.DateTime;
         }
@@ -704,13 +733,11 @@ namespace DurableTask.ServiceBus
 
             var session = sessionState.SessionReceiver;
 
+            // check for lock expired by renewing lock
+            RenewTaskOrchestrationWorkItemLockAsync(workItem);
+
             if (await TrySetSessionStateAsync(workItem, newOrchestrationRuntimeState, runtimeState, session))
             {
-                foreach (var value in sessionState.Messages)
-                {
-                    await session.CompleteMessageAsync(value);
-                }
-
                 if (outboundMessages?.Count > 0)
                 {
                     MessageContainer[] outboundBrokeredMessages = await Task.WhenAll(outboundMessages.Select(async m =>
@@ -838,6 +865,13 @@ namespace DurableTask.ServiceBus
                     return $"Completing orchestration messages sequence and lock tokens: {allIds}";
                 });
 
+            RenewTaskOrchestrationWorkItemLockAsync(workItem);
+
+            foreach (var value in sessionState.Messages)
+            {
+                await session.CompleteMessageAsync(value);
+            }
+
             this.ServiceStats.OrchestrationDispatcherStats.SessionBatchesCompleted.Increment();
         }
 
@@ -923,7 +957,7 @@ namespace DurableTask.ServiceBus
 
             TaskMessage taskMessage = await ServiceBusUtils.GetObjectFromBrokeredMessageAsync<TaskMessage>(receivedMessage, this.BlobStore);
 
-    //TODO        ServiceBusUtils.CheckAndLogDeliveryCount(receivedMessage, this.Settings.MaxTaskActivityDeliveryCount);
+            ServiceBusUtils.CheckAndLogDeliveryCount(receivedMessage, this.Settings.MaxTaskActivityDeliveryCount);
 
             if (!this.orchestrationMessages.TryAdd(receivedMessage.MessageId, receivedMessage))
             {

--- a/src/DurableTask.ServiceBusAMS/Tracking/AzureTableClient.cs
+++ b/src/DurableTask.ServiceBusAMS/Tracking/AzureTableClient.cs
@@ -28,9 +28,7 @@ namespace DurableTask.ServiceBus.Tracking
     using DurableTask.Core.Tracing;
     using Azure;
     using Azure.Data.Tables;
-    using Azure.Core.Pipeline;
     using Azure.Core;
-    using ImpromptuInterface.Dynamic;
 
     internal class AzureTableClient
     {


### PR DESCRIPTION
Changes in this PR:

- Bump version to 2.7.1.0
- Update dependency versions
- Re-lock session lock if lost
- Renew session before completing orchestrator task to determine if lock has been lost
- Prevent benign error that is logged whenever there are no unlocked messages.
- moved session.CompleteMessageAsync(value) to after messaging and update state as the origin sb package does.  Check for lock renewal before completing messages.   The previous servicebus client had an atomic call to complete all messages received, but AMS client does not seem to have this functionality, so each message individually needs to be completed.
- added netstandard2.0 to target frameworks